### PR TITLE
filter: AWS Lambda - Add JSON transcoding support

### DIFF
--- a/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
@@ -20,11 +20,78 @@ If :ref:`payload_passthrough <envoy_api_msg_config.filter.http.aws_lambda.v2alph
 *Note*: This means you lose access to all the HTTP headers in the Lambda function.
 
 However, if :ref:`payload_passthrough <envoy_api_msg_config.filter.http.aws_lambda.v2alpha.config>`
-is set to ``false``, then the HTTP request is transformed to a JSON (the details of the JSON transformation will be
-documented once that feature is implemented).
+is set to ``false``, then the HTTP request is transformed to a JSON payload with the following schema:
+
+.. code-block::
+
+    {
+        "rawPath": "/path/to/resource",
+        "method": "GET|POST|HEAD|...",
+        "headers": {"header-key": "header-value", ... },
+        "queryStringParameters": {"key": "value", ...},
+        "body": "...",
+        "isBase64Encoded": true|false
+    }
+
+- ``rawPath`` is the HTTP request resource path (including the query string)
+- ``method`` is the HTTP request method. For example ``GET``, ``PUT``, etc.
+- ``headers`` are the HTTP request headers. If multiple headers share the same name, their values are
+  coalesced into a single comma-separated value.
+- ``queryStringParameters`` are the HTTP request query string parameters. If multiple parameters share the same name,
+  the last one wins. That is, parameters are _not_ coalesced into a single value if they share the same key name.
+- ``body`` the body of the HTTP request is base64-encoded by the filter if the ``content-type`` header exists and is _not_ one of the following:
+
+    -  text/*
+    -  application/json
+    -  application/xml
+    -  application/javascript
+
+Otherwise, the body of HTTP request is added to the JSON payload as is.
+
+On the other end, the response of the Lambda function must conform to the following schema:
+
+.. code-block::
+
+    {
+        "statusCode": ...
+        "headers": {"header-key": "header-value", ... },
+        "cookies": ["key1=value1; HttpOnly; ...", "key2=value2; Secure; ...", ...],
+        "body": "...",
+        "isBase64Encoded": true|false
+    }
+
+- The ``statusCode`` field is used as the HTTP response code.
+- The ``headers`` are used as the HTTP response headers. If multiple headers share the same name, their values are
+  coalesced into a single comma-separated value. Unlike the request headers, cookies are not part of the response
+  headers because the ``Set-Cookie`` header cannot contain more than one value per the `RFC`_.
+- The ``cookies`` are used as ``Set-Cookie`` response headers.
+- The ``body`` is base64-decoded if it is marked as base64-encoded and sent as the body of the HTTP response.
+
+.. _RFC: https://tools.ietf.org/html/rfc6265#section-4.1
+
+.. note::
+
+    The target cluster must have its endpoint set to the `regional Lambda endpoint`_. Use the same region as the Lambda
+    function.
+
+    AWS IAM credentials must be defined in either environment variables, EC2 metadata or ECS task metadata.
+
+
+.. _regional Lambda endpoint: https://docs.aws.amazon.com/general/latest/gr/lambda-service.html
 
 The filter supports :ref:`per-filter configuration
 <envoy_api_msg_config.filter.http.aws_lambda.v2alpha.PerRouteConfig>`.
+
+If you use the per-filter configuration, the target cluster _must_ have the following metadata:
+
+.. code-block:: yaml
+
+    metadata:
+      filter_metadata:
+        com.amazonaws.lambda:
+          egress_gateway: true
+
+
 Below are some examples the show how the filter can be used in different deployment scenarios.
 
 Example configuration

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,8 +7,10 @@ Version history
   of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 * adaptive concurrency: fixed bug that allowed concurrency limits to drop below the configured
   minimum.
-* aws_request_signing: a few fixes so that it works with S3.
 * admin: added support for displaying ip address subject alternate names in :ref:`certs<operations_admin_interface_certs>` end point.
+* aws_lambda: added :ref:`AWS Lambda filter <config_http_filters_aws_lambda>` that converts HTTP requests to Lambda
+  invokes. This effectively makes Envoy act as an egress gateway to AWS Lambda.
+* aws_request_signing: a few fixes so that it works with S3.
 * buffer: force copy when appending small slices to OwnedImpl buffer to avoid fragmentation.
 * config: use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 * datasource: added retry policy for remote async data source.

--- a/source/extensions/filters/http/aws_lambda/BUILD
+++ b/source/extensions/filters/http/aws_lambda/BUILD
@@ -8,16 +8,24 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_package",
+    "envoy_proto_library",
 )
 
 envoy_package()
+
+envoy_proto_library(
+    name = "request_response",
+    srcs = ["request_response.proto"],
+)
 
 envoy_cc_library(
     name = "aws_lambda_filter_lib",
     srcs = ["aws_lambda_filter.cc"],
     hdrs = ["aws_lambda_filter.h"],
     deps = [
+        ":request_response_cc_proto",
         "//include/envoy/http:filter_interface",
+        "//source/common/common:base64_lib",
         "//source/extensions/common/aws:credentials_provider_impl_lib",
         "//source/extensions/common/aws:signer_impl_lib",
         "//source/extensions/filters/http:well_known_names",

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -212,7 +212,7 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
   }
 
   // Just the existence of this header means we have an error, so skip.
-  if (auto function_error_header = headers.get(Http::LowerCaseString("x-amz-function-error"))) {
+  if (headers.get(Http::LowerCaseString("x-amz-function-error"))) {
     skip_ = true;
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -3,16 +3,26 @@
 #include <string>
 #include <vector>
 
+#include "envoy/http/codes.h"
+#include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
 #include "envoy/upstream/upstream.h"
 
+#include "common/buffer/buffer_impl.h"
+#include "common/common/base64.h"
 #include "common/common/fmt.h"
 #include "common/common/hex.h"
 #include "common/crypto/utility.h"
 #include "common/http/headers.h"
+#include "common/http/utility.h"
+#include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/utility.h"
+
+#include "source/extensions/filters/http/aws_lambda/request_response.pb.validate.h"
 
 #include "extensions/filters/http/well_known_names.h"
 
+#include "absl/strings/numbers.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -24,8 +34,9 @@ namespace {
 
 constexpr auto filter_metadata_key = "com.amazonaws.lambda";
 constexpr auto egress_gateway_metadata_key = "egress_gateway";
+constexpr auto content_type_json = "application/json";
 
-void setHeaders(Http::RequestHeaderMap& headers, absl::string_view function_name) {
+void setLambdaHeaders(Http::RequestHeaderMap& headers, absl::string_view function_name) {
   headers.setMethod(Http::Headers::get().MethodValues.Post);
   headers.setPath(fmt::format("/2015-03-31/functions/{}/invocations", function_name));
   headers.setCopy(Http::LowerCaseString{"x-amz-invocation-type"}, "RequestResponse");
@@ -54,13 +65,49 @@ bool isTargetClusterLambdaGateway(Upstream::ClusterInfo const& cluster_info) {
   return egress_gateway_it->second.bool_value();
 }
 
+bool isContentTypeTextual(const Http::RequestOrResponseHeaderMap& headers) {
+  // If transfer-encoding is anything other than 'identity' (i.e. chunked, compress, deflate or
+  // gzip) then we want to base64-encode it regardless of the content-type value.
+  if (headers.TransferEncoding()) {
+    std::string encoding{headers.TransferEncoding()->value().getStringView()};
+    if (Http::LowerCaseString(encoding).get() != "identity") {
+      return false;
+    }
+  }
+
+  // If we don't know the content-type, then we can't make any assumptions.
+  if (!headers.ContentType()) {
+    return false;
+  }
+
+  const Http::LowerCaseString content_type_value{
+      std::string(headers.ContentType()->value().getStringView())};
+  if (content_type_value.get() == "application/json") {
+    return true;
+  }
+
+  if (content_type_value.get() == "application/javascript") {
+    return true;
+  }
+
+  if (content_type_value.get() == "application/xml") {
+    return true;
+  }
+
+  if (absl::StartsWith(content_type_value.get(), "text/")) {
+    return true;
+  }
+
+  return false;
+}
+
 } // namespace
 
 Filter::Filter(const FilterSettings& settings,
                const std::shared_ptr<Extensions::Common::Aws::Signer>& sigv4_signer)
     : settings_(settings), sigv4_signer_(sigv4_signer) {}
 
-absl::optional<Arn> Filter::calculateRouteArn() {
+absl::optional<FilterSettings> Filter::getRouteSpecificSettings() const {
   if (!decoder_callbacks_->route() || !decoder_callbacks_->route()->routeEntry()) {
     return absl::nullopt;
   }
@@ -71,58 +118,258 @@ absl::optional<Arn> Filter::calculateRouteArn() {
     return absl::nullopt;
   }
 
-  return parseArn(settings->arn());
+  return *settings;
+}
+
+std::string Filter::resolveSettings() {
+  if (auto route_settings = getRouteSpecificSettings()) {
+    if (auto route_arn = parseArn(route_settings->arn())) {
+      arn_.swap(route_arn);
+      payload_passthrough_ = route_settings->payloadPassthrough();
+    } else {
+      ENVOY_LOG(warn, "Found route specific configuration but failed to parse Lambda ARN {}.",
+                route_settings->arn());
+      return "Invalid AWS Lambda ARN";
+    }
+  } else {
+    payload_passthrough_ = settings_.payloadPassthrough();
+  }
+  return {};
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
-  if (!settings_.payloadPassthrough()) {
+  auto cluster_info_ptr = decoder_callbacks_->clusterInfo();
+  ASSERT(cluster_info_ptr);
+  if (!isTargetClusterLambdaGateway(*cluster_info_ptr)) {
     skip_ = true;
+    ENVOY_LOG(trace, "Target cluster does not have the Lambda metadata. Moving on.");
     return Http::FilterHeadersStatus::Continue;
   }
 
-  auto route_arn = calculateRouteArn();
-  if (route_arn.has_value()) {
-    auto cluster_info_ptr = decoder_callbacks_->clusterInfo();
-    ASSERT(cluster_info_ptr);
-    if (!isTargetClusterLambdaGateway(*cluster_info_ptr)) {
-      skip_ = true;
-      return Http::FilterHeadersStatus::Continue;
-    }
-    arn_.swap(route_arn);
-  } else {
+  const auto err = resolveSettings();
+
+  if (!err.empty()) {
+    skip_ = true;
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, err, nullptr /*modify_headers*/,
+                                       absl::nullopt /*grpc_status*/, "" /*details*/);
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  if (!arn_) {
     arn_ = parseArn(settings_.arn());
     if (!arn_.has_value()) {
-      ENVOY_LOG(error, "Unable to parse Lambda ARN {}.", settings_.arn());
+      ENVOY_LOG(error, "Failed to parse Lambda ARN {}.", settings_.arn());
       skip_ = true;
-      return Http::FilterHeadersStatus::Continue;
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "Invalid AWS Lambda ARN",
+                                         nullptr /*modify_headers*/, absl::nullopt /*grpc_status*/,
+                                         "" /*details*/);
+      return Http::FilterHeadersStatus::StopIteration;
     }
   }
 
-  if (end_stream) {
-    setHeaders(headers, arn_->functionName());
+  if (!end_stream) {
+    request_headers_ = &headers;
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  if (payload_passthrough_) {
+    setLambdaHeaders(headers, arn_->functionName());
     sigv4_signer_->sign(headers);
     return Http::FilterHeadersStatus::Continue;
   }
 
-  headers_ = &headers;
+  Buffer::OwnedImpl json_buf;
+  jsonizeRequest(headers, nullptr, json_buf);
+  // We must call setLambdaHeaders *after* the JSON transformation of the request. That way we
+  // reflect the actual incoming request headers instead of the overwritten ones.
+  setLambdaHeaders(headers, arn_->functionName());
+  headers.setContentLength(json_buf.length());
+  headers.setReferenceContentType(content_type_json);
+  auto& hashing_util = Envoy::Common::Crypto::UtilitySingleton::get();
+  const auto hash = Hex::encode(hashing_util.getSha256Digest(json_buf));
+  sigv4_signer_->sign(headers, hash);
+  decoder_callbacks_->addDecodedData(json_buf, false);
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers, bool end_stream) {
+  if (skip_ || end_stream) {
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  // Check for errors returned by Lambda.
+  // If we detect an error, we skip the encodeData step to hand the error back to the user as is.
+  // Errors can be in the form of HTTP status code or x-amz-function-error header
+  if (auto http_status_header = headers.Status()) {
+    auto value = http_status_header->value().getStringView();
+    int code = 0;
+    const auto res = SimpleAtoi(value, &code);
+    ASSERT(res);
+    if (code == 0 || code >= 300) {
+      skip_ = true;
+      return Http::FilterHeadersStatus::Continue;
+    }
+  }
+
+  // Just the existence of this header means we have an error, so skip.
+  if (auto function_error_header = headers.get(Http::LowerCaseString("x-amz-function-error"))) {
+    skip_ = true;
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  response_headers_ = &headers;
   return Http::FilterHeadersStatus::StopIteration;
 }
 
-Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
-  UNREFERENCED_PARAMETER(data);
+Http::FilterDataStatus Filter::decodeData(Buffer::Instance&, bool end_stream) {
   if (skip_) {
     return Http::FilterDataStatus::Continue;
   }
 
-  if (end_stream) {
-    setHeaders(*headers_, arn_->functionName());
-    auto& hashing_util = Envoy::Common::Crypto::UtilitySingleton::get();
-    const Buffer::Instance& decoding_buffer = *decoder_callbacks_->decodingBuffer();
-    const auto hash = Hex::encode(hashing_util.getSha256Digest(decoding_buffer));
-    sigv4_signer_->sign(*headers_, hash);
+  if (!end_stream) {
+    return Http::FilterDataStatus::StopIterationAndBuffer;
+  }
+
+  auto& hashing_util = Envoy::Common::Crypto::UtilitySingleton::get();
+  ASSERT(decoder_callbacks_->decodingBuffer());
+  const Buffer::Instance& decoding_buffer = *decoder_callbacks_->decodingBuffer();
+
+  if (!payload_passthrough_) {
+    decoder_callbacks_->modifyDecodingBuffer([this](Buffer::Instance& data) {
+      Buffer::OwnedImpl json_buf;
+      jsonizeRequest(*request_headers_, &data, json_buf);
+      // effectively swap(data, json_buf)
+      data.drain(data.length());
+      data.move(json_buf);
+    });
+    request_headers_->setContentLength(decoding_buffer.length());
+    request_headers_->setReferenceContentType(content_type_json);
+  }
+
+  setLambdaHeaders(*request_headers_, arn_->functionName());
+  const auto hash = Hex::encode(hashing_util.getSha256Digest(decoding_buffer));
+  sigv4_signer_->sign(*request_headers_, hash);
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterDataStatus Filter::encodeData(Buffer::Instance&, bool end_stream) {
+  if (skip_ || payload_passthrough_) {
     return Http::FilterDataStatus::Continue;
   }
-  return Http::FilterDataStatus::StopIterationAndBuffer;
+
+  if (!end_stream) {
+    return Http::FilterDataStatus::StopIterationAndBuffer;
+  }
+
+  ENVOY_LOG(trace, "Tranforming JSON payload to HTTP response.");
+  ASSERT(encoder_callbacks_->encodingBuffer());
+  const Buffer::Instance& encoding_buffer = *encoder_callbacks_->encodingBuffer();
+  encoder_callbacks_->modifyEncodingBuffer([this](Buffer::Instance& enc_buf) {
+    Buffer::OwnedImpl body;
+    dejsonizeResponse(*response_headers_, enc_buf, body);
+    enc_buf.drain(enc_buf.length());
+    enc_buf.move(body);
+  });
+  response_headers_->setContentLength(encoding_buffer.length());
+  return Http::FilterDataStatus::Continue;
+}
+
+void Filter::jsonizeRequest(Http::RequestHeaderMap const& headers, const Buffer::Instance* body,
+                            Buffer::Instance& out) const {
+  using source::extensions::filters::http::aws_lambda::Request;
+  Request json_req;
+  if (headers.Path()) {
+    json_req.set_raw_path(std::string(headers.Path()->value().getStringView()));
+  }
+
+  if (headers.Method()) {
+    json_req.set_method(std::string(headers.Method()->value().getStringView()));
+  }
+
+  // Wrap the headers
+  headers.iterate(
+      [](const Http::HeaderEntry& entry, void* ctx) -> Http::HeaderMap::Iterate {
+        auto* req = static_cast<Request*>(ctx);
+        // ignore H2 pseudo-headers
+        if (absl::StartsWith(entry.key().getStringView(), ":")) {
+          return Http::HeaderMap::Iterate::Continue;
+        }
+        std::string name = std::string(entry.key().getStringView());
+        auto it = req->mutable_headers()->find(name);
+        if (it == req->headers().end()) {
+          req->mutable_headers()->insert({name, std::string(entry.value().getStringView())});
+        } else {
+          // Coalesce headers with multiple values
+          it->second += fmt::format(",{}", entry.value().getStringView());
+        }
+        return Http::HeaderMap::Iterate::Continue;
+      },
+      &json_req);
+
+  // Wrap the Query String
+  for (auto&& kv_pair : Http::Utility::parseQueryString(headers.Path()->value().getStringView())) {
+    json_req.mutable_query_string_parameters()->insert({kv_pair.first, kv_pair.second});
+  }
+
+  // Wrap the body
+  if (body) {
+    if (isContentTypeTextual(headers)) {
+      json_req.set_body(body->toString());
+      json_req.set_is_base64_encoded(false);
+    } else {
+      json_req.set_body(Base64::encode(*body, body->length()));
+      json_req.set_is_base64_encoded(true);
+    }
+  }
+
+  MessageUtil::validate(json_req, ProtobufMessage::getStrictValidationVisitor());
+  Protobuf::util::JsonPrintOptions json_options;
+  json_options.always_print_primitive_fields = true;
+  std::string json_data;
+  const auto status = Protobuf::util::MessageToJsonString(json_req, &json_data, json_options);
+  ASSERT(status.ok());
+  out.add(json_data);
+}
+
+void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::Instance& json_buf,
+                               Buffer::Instance& body) const {
+  using source::extensions::filters::http::aws_lambda::Response;
+  Response json_resp;
+  try {
+    MessageUtil::loadFromJson(json_buf.toString(), json_resp,
+                              ProtobufMessage::getNullValidationVisitor());
+  } catch (EnvoyException& ex) {
+    // We would only get here if all of the following are true:
+    // 1- Passthrough is set to false
+    // 2- Lambda returned a 200 OK
+    // 3- There was no x-amz-function-error header
+    // 4- The body contains invalid JSON
+    headers.setStatus(static_cast<int>(Http::Code::InternalServerError));
+    ENVOY_LOG(error, "Failed to parse JSON response from AWS Lambda.\n{}", ex.what());
+    return;
+  }
+
+  for (auto&& kv : json_resp.headers()) {
+    // ignore H2 pseudo-headers (if any)
+    if (kv.first[0] == ':') {
+      continue;
+    }
+    headers.setCopy(Http::LowerCaseString(kv.first), kv.second);
+  }
+
+  for (auto&& cookie : json_resp.cookies()) {
+    headers.addReferenceKey(Http::Headers::get().SetCookie, cookie);
+  }
+
+  headers.setStatus(json_resp.status_code());
+  headers.setReferenceContentType(content_type_json);
+  if (!json_resp.body().empty()) {
+    if (json_resp.is_base64_encoded()) {
+      body.add(Base64::decode(json_resp.body()));
+    } else {
+      body.add(json_resp.body());
+    }
+  }
 }
 
 absl::optional<Arn> parseArn(absl::string_view arn) {

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -4,6 +4,8 @@
 
 #include "envoy/http/filter.h"
 
+#include "common/buffer/buffer_impl.h"
+
 #include "extensions/common/aws/signer.h"
 #include "extensions/filters/http/common/pass_through_filter.h"
 
@@ -70,19 +72,33 @@ public:
   Filter(const FilterSettings& config,
          const std::shared_ptr<Extensions::Common::Aws::Signer>& sigv4_signer);
 
-  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
-                                          bool end_stream) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
 
-private:
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool end_stream) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
+
   /**
-   * Calculates the route specific Lambda ARN if any.
+   * Calculates the function ARN, value of pass-through, etc. by checking per-filter configurations
+   * and general filter configuration. Ultimately, the most specific configuration wins.
+   * @return error message if settings are invalid. Otherwise, empty string.
    */
-  absl::optional<Arn> calculateRouteArn();
+  std::string resolveSettings();
+
+private:
+  absl::optional<FilterSettings> getRouteSpecificSettings() const;
+  // Convert the HTTP request to JSON request.
+  void jsonizeRequest(const Http::RequestHeaderMap& headers, const Buffer::Instance* body,
+                      Buffer::Instance& out) const;
+  // Convert the JSON response to a standard HTTP response.
+  void dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::Instance& body,
+                         Buffer::Instance& out) const;
   const FilterSettings settings_;
-  Http::RequestHeaderMap* headers_ = nullptr;
+  Http::RequestHeaderMap* request_headers_ = nullptr;
+  Http::ResponseHeaderMap* response_headers_ = nullptr;
   std::shared_ptr<Extensions::Common::Aws::Signer> sigv4_signer_;
   absl::optional<Arn> arn_;
+  bool payload_passthrough_ = false;
   bool skip_ = false;
 };
 

--- a/source/extensions/filters/http/aws_lambda/request_response.proto
+++ b/source/extensions/filters/http/aws_lambda/request_response.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+// The structures are used for the purpose of JSON (de)serialization.
+package source.extensions.filters.http.aws_lambda;
+
+import "validate/validate.proto";
+
+message Request {
+  string raw_path = 1 [(validate.rules).string = {min_len: 1}];
+
+  string method = 2 [(validate.rules).string = {min_len: 1}];
+  // HTTP headers with the same name are coalesced into a single comma-separated value.
+  map<string, string> headers = 3;
+
+  // multi-value keys are overwritten. Last one wins.
+  map<string, string> query_string_parameters = 4;
+
+  string body = 5;
+
+  bool is_base64_encoded = 6;
+}
+
+message Response {
+  uint32 status_code = 1;
+  map<string, string> headers = 2;
+  // cookies are split from headers in the response because the headers are coalesced while the HTTP RFC prohibits
+  // coalescing multiple cookie values in the Set-Cookie header.
+  repeated string cookies = 3;
+  string body = 4;
+  bool is_base64_encoded = 5;
+}

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -1,4 +1,9 @@
+#include <vector>
+
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/http/filter.h"
+
+#include "source/extensions/filters/http/aws_lambda/request_response.pb.validate.h"
 
 #include "extensions/filters/http/aws_lambda/aws_lambda_filter.h"
 #include "extensions/filters/http/well_known_names.h"
@@ -17,9 +22,12 @@ namespace AwsLambdaFilter {
 namespace {
 
 using Common::Aws::MockSigner;
+using ::testing::ElementsAre;
 using ::testing::Invoke;
+using ::testing::Pair;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::UnorderedElementsAre;
 
 constexpr auto Arn = "arn:aws:lambda:us-west-2:1337:function:fun";
 class AwsLambdaFilterTest : public ::testing::Test {
@@ -28,11 +36,20 @@ public:
     signer_ = std::make_shared<NiceMock<MockSigner>>();
     filter_ = std::make_unique<Filter>(settings, signer_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+    const std::string metadata_yaml = "egress_gateway: true";
+
+    ProtobufWkt::Struct cluster_metadata;
+    TestUtility::loadFromYaml(metadata_yaml, cluster_metadata);
+    metadata_.mutable_filter_metadata()->insert({"com.amazonaws.lambda", cluster_metadata});
+    ON_CALL(*decoder_callbacks_.cluster_info_, metadata()).WillByDefault(ReturnRef(metadata_));
   }
 
   std::unique_ptr<Filter> filter_;
   std::shared_ptr<NiceMock<MockSigner>> signer_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+  envoy::config::core::v3::Metadata metadata_;
 };
 
 /**
@@ -46,29 +63,44 @@ TEST_F(AwsLambdaFilterTest, DecodingHeaderStopIteration) {
 }
 
 /**
- * Header only requests should be signed and Continue iteration.
- * Also, if x-forwarded-proto header is found, it should be removed when signing.
+ * Header only pass-through requests should be signed and Continue iteration.
  */
 TEST_F(AwsLambdaFilterTest, HeaderOnlyShouldContinue) {
   setupFilter({Arn, true /*passthrough*/});
-  Http::TestRequestHeaderMapImpl input_headers{{":method", "GET"}, {"x-forwarded-proto", "http"}};
+  EXPECT_CALL(*signer_, sign(_));
+  Http::TestRequestHeaderMapImpl input_headers;
   const auto result = filter_->decodeHeaders(input_headers, true /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+
+  Http::TestResponseHeaderMapImpl response_headers;
+  const auto encode_result = filter_->encodeHeaders(response_headers, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, encode_result);
 }
 
 /**
- * If there's a per-route configuration and the target cluster does not have the AWS Lambda
- * metadata, then we should skip the filter.
+ * If the filter is configured with an invalid ARN, then we stop.
  */
-TEST_F(AwsLambdaFilterTest, PerRouteConfigNoClusterMetadata) {
+TEST_F(AwsLambdaFilterTest, ConfigurationWithInvalidARN) {
+  setupFilter({"BadARN", true /*passthrough*/});
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply);
+  Http::TestRequestHeaderMapImpl headers;
+  const auto result = filter_->decodeHeaders(headers, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, result);
+}
+
+/**
+ * If there's a per-route configuration with an invalid ARN, then we stop.
+ */
+TEST_F(AwsLambdaFilterTest, PerRouteConfigWithInvalidARN) {
   setupFilter({Arn, true /*passthrough*/});
-  FilterSettings route_settings{Arn, true /*passthrough*/};
+  FilterSettings route_settings{"BadARN", true /*passthrough*/};
   ON_CALL(decoder_callbacks_.route_->route_entry_,
           perFilterConfig(HttpFilterNames::get().AwsLambda))
       .WillByDefault(Return(&route_settings));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply);
   Http::TestRequestHeaderMapImpl headers;
   const auto result = filter_->decodeHeaders(headers, true /*end_stream*/);
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, result);
 }
 
 /**
@@ -81,7 +113,7 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
   )EOF";
 
   ProtobufWkt::Struct cluster_metadata;
-  envoy::config::core::v3::Metadata metadata; // What should this type be?
+  envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(metadata_yaml, cluster_metadata);
   metadata.mutable_filter_metadata()->insert({"WrongMetadataKey", cluster_metadata});
 
@@ -93,8 +125,14 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
 
   ON_CALL(*decoder_callbacks_.cluster_info_, metadata()).WillByDefault(ReturnRef(metadata));
   Http::TestRequestHeaderMapImpl headers;
-  const auto result = filter_->decodeHeaders(headers, false /*end_stream*/);
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+
+  const auto decode_header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, decode_header_result);
+
+  Buffer::OwnedImpl buf;
+  const auto decode_data_result = filter_->decodeData(buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, decode_data_result);
+  EXPECT_EQ(0, buf.length());
 }
 
 /**
@@ -102,22 +140,12 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
  * process the request (i.e. StopIteration if end_stream is false)
  */
 TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectClusterMetadata) {
-  const std::string metadata_yaml = R"EOF(
-  egress_gateway: true
-  )EOF";
-
-  ProtobufWkt::Struct cluster_metadata;
-  envoy::config::core::v3::Metadata metadata; // What should this type be?
-  TestUtility::loadFromYaml(metadata_yaml, cluster_metadata);
-  metadata.mutable_filter_metadata()->insert({"com.amazonaws.lambda", cluster_metadata});
-
   setupFilter({Arn, true /*passthrough*/});
   FilterSettings route_settings{Arn, true /*passthrough*/};
   ON_CALL(decoder_callbacks_.route_->route_entry_,
           perFilterConfig(HttpFilterNames::get().AwsLambda))
       .WillByDefault(Return(&route_settings));
 
-  ON_CALL(*decoder_callbacks_.cluster_info_, metadata()).WillByDefault(ReturnRef(metadata));
   Http::TestRequestHeaderMapImpl headers;
   const auto result = filter_->decodeHeaders(headers, false /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, result);
@@ -142,6 +170,376 @@ TEST_F(AwsLambdaFilterTest, DecodeDataShouldSign) {
   ON_CALL(decoder_callbacks_, decodingBuffer()).WillByDefault(Return(&buffer));
   const auto data_result = filter_->decodeData(buffer, true /*end_stream*/);
   EXPECT_EQ(Http::FilterDataStatus::Continue, data_result);
+}
+
+/**
+ * A header-only request with pass-through turned off should result in:
+ * - a request with JSON body.
+ * - content-length header set appropriately
+ * - content-type header set to application/json
+ * - headers with multiple values coalesced with a comma
+ */
+TEST_F(AwsLambdaFilterTest, DecodeHeadersOnlyRequestWithJsonOn) {
+  using source::extensions::filters::http::aws_lambda::Request;
+  setupFilter({Arn, false /*passthrough*/});
+  Buffer::OwnedImpl json_buf;
+  auto on_add_decoded_data = [&json_buf](Buffer::Instance& buf, bool) { json_buf.move(buf); };
+  ON_CALL(decoder_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke(on_add_decoded_data));
+  Http::TestRequestHeaderMapImpl headers;
+  headers.setContentLength(0);
+  headers.setPath("/resource?proxy=envoy");
+  headers.setMethod("GET");
+  headers.addCopy("x-custom-header", "unit");
+  headers.addCopy("x-custom-header", "test");
+  const auto header_result = filter_->decodeHeaders(headers, true /*end_stream*/);
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, header_result);
+
+  // Assert it's not empty
+  ASSERT_GT(json_buf.length(), 0);
+
+  ASSERT_NE(headers.ContentType(), nullptr);
+  EXPECT_EQ("application/json", headers.ContentType()->value().getStringView());
+
+  // Assert the true (post-transformation) content-length sent to the Lambda endpoint.
+  ASSERT_NE(headers.ContentLength(), nullptr);
+  EXPECT_EQ(fmt::format("{}", json_buf.length()), headers.ContentLength()->value().getStringView());
+
+  // The best way to verify the generated JSON is to deserialize it and inspect it.
+  Request req;
+  TestUtility::loadFromJson(json_buf.toString(), req);
+
+  // Assert the content-length wrapped in JSON reflects the original request's value.
+  EXPECT_THAT(req.headers(), UnorderedElementsAre(Pair("content-length", "0"),
+                                                  Pair("x-custom-header", "unit,test")));
+  EXPECT_THAT(req.query_string_parameters(), UnorderedElementsAre(Pair("proxy", "envoy")));
+  EXPECT_STREQ("/resource?proxy=envoy", req.raw_path().c_str());
+  EXPECT_FALSE(req.is_base64_encoded());
+  EXPECT_TRUE(req.body().empty());
+  EXPECT_STREQ("GET", req.method().c_str());
+}
+
+/**
+ * A request with text payload and pass-through turned off should result in:
+ * - a request with JSON body containing the original payload
+ * - content-length header set appropriately
+ * - content-type header set to application/json
+ * - headers with multiple values coalesced with a comma
+ */
+TEST_F(AwsLambdaFilterTest, DecodeDataWithTextualBodyWithJsonOn) {
+  using source::extensions::filters::http::aws_lambda::Request;
+  setupFilter({Arn, false /*passthrough*/});
+
+  Buffer::OwnedImpl decoded_buf;
+  constexpr absl::string_view expected_plain_text = "Foo bar bazz";
+  decoded_buf.add(expected_plain_text);
+
+  auto on_modify_decoding_buffer = [&decoded_buf](std::function<void(Buffer::Instance&)> cb) {
+    cb(decoded_buf);
+  };
+  EXPECT_CALL(decoder_callbacks_, decodingBuffer).WillRepeatedly(Return(&decoded_buf));
+  EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer)
+      .WillRepeatedly(Invoke(on_modify_decoding_buffer));
+
+  std::array<const char*, 4> textual_mime_types = {"application/json", "application/javascript",
+                                                   "application/xml", "text/plain"};
+
+  for (auto mime_type : textual_mime_types) {
+    Http::TestRequestHeaderMapImpl headers;
+    headers.setContentLength(expected_plain_text.length());
+    headers.setPath("/resource?proxy=envoy");
+    headers.setMethod("POST");
+    headers.setContentType(mime_type);
+    headers.addCopy("x-custom-header", "unit");
+    headers.addCopy("x-custom-header", "test");
+    const auto header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
+    ASSERT_EQ(Http::FilterHeadersStatus::StopIteration, header_result);
+
+    const auto data_result = filter_->decodeData(decoded_buf, true /*end_stream*/);
+    ASSERT_EQ(Http::FilterDataStatus::Continue, data_result);
+
+    // Assert decoded buffer is not drained
+    ASSERT_GT(decoded_buf.length(), 0);
+
+    ASSERT_NE(headers.ContentType(), nullptr);
+    EXPECT_EQ("application/json", headers.ContentType()->value().getStringView());
+
+    // Assert the true (post-transformation) content-length sent to the Lambda endpoint.
+    ASSERT_NE(headers.ContentLength(), nullptr);
+    EXPECT_EQ(fmt::format("{}", decoded_buf.length()),
+              headers.ContentLength()->value().getStringView());
+
+    // The best way to verify the generated JSON is to deserialize it and inspect it.
+    Request req;
+    TestUtility::loadFromJson(decoded_buf.toString(), req);
+
+    // Assert the content-length wrapped in JSON reflects the original request's value.
+    EXPECT_THAT(req.headers(),
+                UnorderedElementsAre(
+                    Pair("content-length", fmt::format("{}", expected_plain_text.length())),
+                    Pair("content-type", mime_type), Pair("x-custom-header", "unit,test")));
+    EXPECT_THAT(req.query_string_parameters(), UnorderedElementsAre(Pair("proxy", "envoy")));
+    EXPECT_STREQ("/resource?proxy=envoy", req.raw_path().c_str());
+    EXPECT_STREQ("POST", req.method().c_str());
+    EXPECT_FALSE(req.is_base64_encoded());
+    ASSERT_FALSE(req.body().empty());
+    EXPECT_STREQ(expected_plain_text.data(), req.body().c_str());
+
+    // reset the buffer for the next iteration
+    decoded_buf.drain(decoded_buf.length());
+    decoded_buf.add(expected_plain_text);
+  }
+}
+
+/**
+ * A request with binary payload and pass-through turned off should result in a JSON payload with
+ * isBase64Encoded flag set.
+ * binary payload is determined by looking at both transfer-encoding and content-type.
+ */
+TEST_F(AwsLambdaFilterTest, DecodeDataWithBinaryBodyWithJsonOn) {
+  using source::extensions::filters::http::aws_lambda::Request;
+  setupFilter({Arn, false /*passthrough*/});
+
+  Buffer::OwnedImpl decoded_buf;
+  const absl::string_view fake_binary_data = "this should get base64 encoded";
+  decoded_buf.add(fake_binary_data);
+  EXPECT_CALL(decoder_callbacks_, decodingBuffer).WillRepeatedly(Return(&decoded_buf));
+  auto on_modify_decoding_buffer = [&decoded_buf](std::function<void(Buffer::Instance&)> cb) {
+    cb(decoded_buf);
+  };
+  EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer)
+      .WillRepeatedly(Invoke(on_modify_decoding_buffer));
+  std::array<absl::string_view, 3> binary_mime_types = {"", "application/pdf", "gzipped"};
+  for (auto mime_type : binary_mime_types) {
+    Http::TestRequestHeaderMapImpl headers;
+    headers.setPath("/");
+    headers.setMethod("POST");
+    headers.setContentLength(fake_binary_data.length());
+    if (mime_type == "gzipped") {
+      headers.setTransferEncoding("gzip");
+    } else if (!mime_type.empty()) {
+      headers.setContentType(mime_type);
+    }
+    const auto header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
+    ASSERT_EQ(Http::FilterHeadersStatus::StopIteration, header_result);
+
+    const auto data_result = filter_->decodeData(decoded_buf, true /*end_stream*/);
+    ASSERT_EQ(Http::FilterDataStatus::Continue, data_result);
+
+    // The best way to verify the generated JSON is to deserialize it and inspect it.
+    Request req;
+    TestUtility::loadFromJson(decoded_buf.toString(), req);
+
+    ASSERT_TRUE(req.is_base64_encoded());
+    ASSERT_FALSE(req.body().empty());
+    ASSERT_STREQ(req.body().c_str(), "dGhpcyBzaG91bGQgZ2V0IGJhc2U2NCBlbmNvZGVk");
+
+    // reset the buffer for the next iteration
+    decoded_buf.drain(decoded_buf.length());
+    decoded_buf.add(fake_binary_data);
+  }
+}
+
+TEST_F(AwsLambdaFilterTest, EncodeHeadersEndStreamShouldSkip) {
+  setupFilter({Arn, true /*passthrough*/});
+  Http::TestResponseHeaderMapImpl headers;
+  auto result = filter_->encodeHeaders(headers, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+
+  setupFilter({Arn, false /*passthrough*/});
+  result = filter_->encodeHeaders(headers, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+}
+
+/**
+ * If the Lambda function itself raises an error (syntax, exception, etc.) then we should skip
+ * encoding headers and skip the filter.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambdaErrorShouldSkipAndContinue) {
+  setupFilter({Arn, false /*passthrough*/});
+  Http::TestResponseHeaderMapImpl headers;
+  headers.addReference(Http::LowerCaseString("x-Amz-Function-Error"), "unhandled");
+  auto result = filter_->encodeHeaders(headers, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+}
+
+/**
+ * If Lambda returns a 5xx error then we should skip encoding headers and skip the filter.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambda5xxShouldSkipAndContinue) {
+  setupFilter({Arn, false /*passthrough*/});
+  Http::TestResponseHeaderMapImpl headers;
+  headers.setStatus(500);
+  auto result = filter_->encodeHeaders(headers, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+}
+
+/**
+ * encodeHeaders() in a happy path should stop iteration.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeHeadersStopsIteration) {
+  setupFilter({Arn, false /*passthrough*/});
+  Http::TestResponseHeaderMapImpl headers;
+  auto result = filter_->encodeHeaders(headers, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, result);
+}
+
+/**
+ * encodeData() data in pass-through mode should simply return Continue.
+ * This is true whether end_stream is true or false.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeDataInPassThroughMode) {
+  setupFilter({Arn, true /*passthrough*/});
+  Buffer::OwnedImpl buf;
+  filter_->resolveSettings();
+  auto result = filter_->encodeData(buf, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+
+  result = filter_->encodeData(buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+}
+
+/**
+ * encodeData() data in JSON mode should stop iteration if end_stream is false.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeStopIterationAndBuffer) {
+  setupFilter({Arn, false /*passthrough*/});
+  Buffer::OwnedImpl buf;
+  filter_->resolveSettings();
+  auto result = filter_->encodeData(buf, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, result);
+}
+
+/**
+ * encodeData() data in JSON mode without a 'body' key should translate the 'headers' key to HTTP
+ * headers while ignoring any HTTP/2 pseudo-headers.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
+  setupFilter({Arn, false /*passthrough*/});
+  filter_->resolveSettings();
+  Http::TestResponseHeaderMapImpl headers;
+  filter_->encodeHeaders(headers, false /*end_stream*/);
+
+  constexpr auto json_response = R"EOF(
+  {
+      "statusCode": 201,
+      "headers": {
+                    "x-awesome-header": "awesome value",
+                    ":other": "should_never_make_it"
+                 },
+      "cookies": ["session-id=42; Secure; HttpOnly", "user=joe"]
+  }
+  )EOF";
+
+  Buffer::OwnedImpl encoded_buf;
+  encoded_buf.add(json_response);
+  auto on_modify_encoding_buffer = [&encoded_buf](std::function<void(Buffer::Instance&)> cb) {
+    cb(encoded_buf);
+  };
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer).WillRepeatedly(Return(&encoded_buf));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer)
+      .WillRepeatedly(Invoke(on_modify_encoding_buffer));
+
+  auto result = filter_->encodeData(encoded_buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+
+  EXPECT_EQ(nullptr, headers.get(Http::LowerCaseString(":other")));
+
+  const auto* custom_header = headers.get(Http::LowerCaseString("x-awesome-header"));
+  EXPECT_NE(custom_header, nullptr);
+  EXPECT_STREQ("awesome value", custom_header->value().getStringView().data());
+
+  std::vector<std::string> cookies;
+  headers.iterate(
+      [](const Http::HeaderEntry& entry, void* ctx) {
+        auto* list = static_cast<std::vector<std::string>*>(ctx);
+        if (entry.key().getStringView() == Http::Headers::get().SetCookie.get()) {
+          list->emplace_back(entry.value().getStringView());
+        }
+        return Http::HeaderMap::Iterate::Continue;
+      },
+      &cookies);
+
+  EXPECT_THAT(cookies, ElementsAre("session-id=42; Secure; HttpOnly", "user=joe"));
+}
+
+/**
+ * encodeData() in JSON mode with a non-empty body should translate the body to plain text if it was
+ * base64-encoded.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeBase64EncodedBody) {
+  setupFilter({Arn, false /*passthrough*/});
+  filter_->resolveSettings();
+  Http::TestResponseHeaderMapImpl headers;
+  filter_->encodeHeaders(headers, false /*end_stream*/);
+
+  constexpr auto json_base64_body = R"EOF(
+  {
+      "statusCode": 201,
+      "body": "Q29mZmVl",
+      "isBase64Encoded": true
+  }
+  )EOF";
+
+  constexpr auto json_plain_text_body = R"EOF(
+  {
+      "statusCode": 201,
+      "body": "Beans",
+      "isBase64Encoded": false
+  }
+  )EOF";
+
+  Buffer::OwnedImpl encoded_buf;
+  encoded_buf.add(json_base64_body);
+  auto on_modify_encoding_buffer = [&encoded_buf](std::function<void(Buffer::Instance&)> cb) {
+    cb(encoded_buf);
+  };
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer).WillRepeatedly(Return(&encoded_buf));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer)
+      .WillRepeatedly(Invoke(on_modify_encoding_buffer));
+
+  auto result = filter_->encodeData(encoded_buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+  EXPECT_STREQ("Coffee", encoded_buf.toString().c_str());
+
+  encoded_buf.drain(encoded_buf.length());
+
+  encoded_buf.add(json_plain_text_body);
+  result = filter_->encodeData(encoded_buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+  EXPECT_STREQ("Beans", encoded_buf.toString().c_str());
+}
+
+/**
+ * Encode data in JSON mode _returning_ invalid JSON payload should result in a 500 error.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeInvalidJson) {
+  setupFilter({Arn, false /*passthrough*/});
+  filter_->resolveSettings();
+  Http::TestResponseHeaderMapImpl headers;
+  filter_->encodeHeaders(headers, false /*end_stream*/);
+
+  constexpr auto json_response = R"EOF(
+  <response>
+        <body>Does XML work??</body>
+  </response>
+  )EOF";
+
+  Buffer::OwnedImpl encoded_buf;
+  encoded_buf.add(json_response);
+  auto on_modify_encoding_buffer = [&encoded_buf](std::function<void(Buffer::Instance&)> cb) {
+    cb(encoded_buf);
+  };
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer).WillRepeatedly(Return(&encoded_buf));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer)
+      .WillRepeatedly(Invoke(on_modify_encoding_buffer));
+
+  auto result = filter_->encodeData(encoded_buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+  EXPECT_EQ(0, encoded_buf.length());
+
+  ASSERT_NE(nullptr, headers.Status());
+  EXPECT_EQ("500", headers.Status()->value().getStringView());
 }
 
 } // namespace

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -358,7 +358,7 @@ TEST_F(AwsLambdaFilterTest, EncodeHeadersEndStreamShouldSkip) {
 TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambdaErrorShouldSkipAndContinue) {
   setupFilter({Arn, false /*passthrough*/});
   Http::TestResponseHeaderMapImpl headers;
-  headers.addReference(Http::LowerCaseString("x-Amz-Function-Error"), "unhandled");
+  headers.addCopy(Http::LowerCaseString("x-Amz-Function-Error"), "unhandled");
   auto result = filter_->encodeHeaders(headers, false /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
 }
@@ -447,7 +447,7 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
 
   const auto* custom_header = headers.get(Http::LowerCaseString("x-awesome-header"));
   EXPECT_NE(custom_header, nullptr);
-  EXPECT_STREQ("awesome value", custom_header->value().getStringView().data());
+  EXPECT_EQ("awesome value", custom_header->value().getStringView());
 
   std::vector<std::string> cookies;
   headers.iterate(


### PR DESCRIPTION
This patch adds a new mode of operation to the Lambda filter. The new
mode allows the filter to do HTTP<=>JSON transcoding.

The JSON schema for the request and the response is in a private
protobuf file.

This patch also removes the WIP flag.

Signed-off-by: Marco Magdy <mmagdy@gmail.com>